### PR TITLE
Wait for supervisor

### DIFF
--- a/roles/tower-setup/tasks/main.yaml
+++ b/roles/tower-setup/tasks/main.yaml
@@ -72,6 +72,16 @@
   tags:
     - tower-install
 
+- name: Wait for supervisor
+  shell:
+    executable: /bin/bash
+    cmd: |
+     set -o errexit -o pipefail
+     supervisorctl status | awk '$2 != "RUNNING" { print $2 }'
+  register: supervisorctl_status
+  until: supervisorctl_status is success and supervisorctl_status.stdout == ''
+  retries: 6
+
 - name: Install ansible-tower-cli
   become: yes
   package:


### PR DESCRIPTION
Wait for supervisor: otherwise subsequent task `Configure or update license` fails due to the `supervisorctl reload` task (see ansible-tower-setup/roles/supervisor/tasks/tasks.yml) executed at the end by the tower installation program. The reload causes a restart of the `uwsgi` service: any query submitted during this restart fails.